### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,47 +1,47 @@
 {
-    "name" : "grunt-prepare-build",
-    "description" : "A Grunt plugin to prepare your build process. Update the version number, Commit the last changes and create a GIT tag.",
-    "version" : "0.1.3",
-    "homepage" : "https://github.com/WitteStier/grunt-prepare-build",
-    "author" : {
-        "name" : "WitteStier",
-        "email" : "github@wittestier.nl"
+    "name": "grunt-prepare-build",
+    "description": "A Grunt plugin to prepare your build process. Update the version number, Commit the last changes and create a GIT tag.",
+    "version": "0.1.3",
+    "homepage": "https://github.com/WitteStier/grunt-prepare-build",
+    "author": {
+        "name": "WitteStier",
+        "email": "github@wittestier.nl"
     },
-    "repository" : {
-        "type" : "git",
-        "url" : "https://github.com/WitteStier/grunt-prepare-build.git"
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/WitteStier/grunt-prepare-build.git"
     },
-    "bugs" : {
-        "url" : "https://github.com/WitteStier/grunt-prepare-build/issues"
+    "bugs": {
+        "url": "https://github.com/WitteStier/grunt-prepare-build/issues"
     },
-    "licenses" : [
+    "licenses": [
         {
-            "type" : "MIT",
-            "url" : "https://github.com/WitteStier/grunt-prepare-build/blob/master/LICENSE-MIT"
+            "type": "MIT",
+            "url": "https://github.com/WitteStier/grunt-prepare-build/blob/master/LICENSE-MIT"
         }
     ],
-    "engines" : {
-        "node" : ">= 0.8.0"
+    "engines": {
+        "node": ">= 0.8.0"
     },
-    "scripts" : {
-        "test" : "grunt test"
+    "scripts": {
+        "test": "grunt test"
     },
-    "dependencies" : {
-        "grunt-git" : "0.2.10",
-        "async" : "~0.2.9"
+    "dependencies": {
+        "grunt-git": "0.2.10",
+        "async": "~0.2.9"
     },
-    "devDependencies" : {
-        "grunt-contrib-jshint" : "^0.9.2",
-        "grunt-contrib-clean" : "^0.5.0",
-        "grunt-contrib-copy" : "0.5.0",
-        "grunt-contrib-nodeunit" : "^0.3.3",
-        "grunt" : "~0.4.5",
-        "grunt-git" : "0.2.10"
+    "devDependencies": {
+        "grunt-contrib-jshint": "^0.9.2",
+        "grunt-contrib-clean": "^0.5.0",
+        "grunt-contrib-copy": "0.5.0",
+        "grunt-contrib-nodeunit": "^0.3.3",
+        "grunt": "~0.4.5",
+        "grunt-git": "0.2.10"
     },
-    "peerDependencies" : {
-        "grunt" : "~0.4.5"
+    "peerDependencies": {
+        "grunt": ">=0.4.0"
     },
-    "keywords" : [
+    "keywords": [
         "gruntplugin"
     ]
 }


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0


Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
